### PR TITLE
Make simple fields create text Node, rather than just primitive value

### DIFF
--- a/src/hooks/sourceNodes/createNodeFromEntity/item/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/item/index.js
@@ -25,7 +25,7 @@ module.exports = function buildItemNode(
           node.digest = entity.meta.updatedAt;
 
           entity.itemType.fields
-            .filter(field => field.fieldType === 'text')
+            .filter(field => field.fieldType === 'string' || field.fieldType === 'text')
             .forEach(field => {
               const camelizedApiKey = camelize(field.apiKey);
 

--- a/src/hooks/sourceNodes/createTypes/item/index.js
+++ b/src/hooks/sourceNodes/createTypes/item/index.js
@@ -22,7 +22,7 @@ const fieldResolvers = {
   rich_text: require('./fields/richText'),
   seo: simpleFieldReturnCamelizedKeys('DatoCmsSeoField'),
   slug: simpleField('String'),
-  string: simpleField('String'),
+  string: require('./fields/text'),
   text: require('./fields/text'),
   video: simpleFieldReturnCamelizedKeys('DatoCmsVideoField'),
 };


### PR DESCRIPTION
This includes changes from my own fork, to open simple text values from DatoCMS to `gatsby-transformer-` plugins